### PR TITLE
Allow UTF8_STRING in INCR transfers as well as XA_STRING

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -542,8 +542,8 @@ get_append_property (XSelectionEvent * xsl, unsigned char ** buffer,
 
   debug_property (D_TRACE, xsl->requestor, xsl->property, target, length);
 
-  if (target != XA_STRING) {
-    print_debug (D_OBSC, "target %s not XA_STRING in get_append_property()",
+  if (target != XA_STRING && target != utf8_atom) {
+    print_debug (D_OBSC, "target %s not XA_STRING nor UTF8_STRING in get_append_property()",
                  get_atom_name (target));
     free (*buffer);
     *buffer = NULL;


### PR DESCRIPTION
See https://bugzilla.gnome.org/show_bug.cgi?id=671066 for the bug that
started this.

Xsel was only accepting XA_STRING during INCR transfers; now
it also takes in UTF8_STRING.  Maybe this bug wasn't triggered
before because most selection transfers are small, and the transfer
described in the bug is quite large.
