### PR TITLE
Fix segfault when stdin is empty

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -949,7 +949,7 @@ initialise_read (unsigned char * read_buffer)
   int insize = in_statbuf.st_blksize;
   unsigned char * new_buffer = NULL;
 
-  if (S_ISREG (in_statbuf.st_mode)) {
+  if (S_ISREG (in_statbuf.st_mode) && in_statbuf.st_size > 0) {
     current_alloc += in_statbuf.st_size;
   } else {
     current_alloc += insize;


### PR DESCRIPTION
When reading input from stdin, ensure the initial read buffer capacity
is greater than zero. This prevents the program from crashing when
writing the null terminator to the buffer in read_input.

How to reproduce:

```sh
$ touch empty
$ xsel <empty
Segmentation fault (core dumped)
$ gdb -c xsel.core xsel
#0  0x0000046261b0381b in read_input (read_buffer=0x464b8715bb0 <Address 0x464b8715bb0 out of bounds>, do_select=0) at xsel.c:918
918       read_buffer[total_input] = '\0';
```