### PR TITLE
Set timer value to 0 to stop timer, don't use a nullptr timer

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -91,6 +91,7 @@ static int current_alloc = 0;
 
 static long timeout = 0;
 static struct itimerval timer;
+static struct itimerval zerot;
 
 #define USEC_PER_SEC 1000000
 
@@ -757,7 +758,8 @@ wait_selection (Atom selection, Atom request_target)
   /* Now that we've received the SelectionNotify event, clear any
    * remaining timeout. */
   if (timeout > 0) {
-    setitimer (ITIMER_REAL, (struct itimerval *)0, (struct itimerval *)0);
+    // setitimer (ITIMER_REAL, (struct itimerval *)0, (struct itimerval *)0);
+    setitimer (ITIMER_REAL, &zerot, (struct itimerval *)0);
   }
 
   return retval;
@@ -2030,6 +2032,11 @@ main(int argc, char *argv[])
   unsigned char * old_sel = NULL, * new_sel = NULL;
   char * display_name = NULL;
   long timeout_ms = 0L;
+
+  zerot.it_value.tv_sec = 0;
+  zerot.it_value.tv_usec = 0;
+  zerot.it_interval.tv_sec = 0;
+  zerot.it_interval.tv_usec = 0;
 
   progname = argv[0];
 


### PR DESCRIPTION
Saw this in my kernel msgs:
kern  :warn  : [Mon Dec  3 17:32:21 2018] xsel calls setitimer() with new_value NULL pointer. Misfeature support will be removed
And submitted this change