### PR TITLE
Avoid extra char copy in strncpy

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -233,7 +233,8 @@ static char *
 get_atom_name (Atom atom)
 {
   char * ret;
-  static char atom_name[MAXLINE+1];
+  static char atom_name[MAXLINE+2];  /* unused extra char to avoid
+                                        string-op-truncation warning */
 
   if (atom == None) return "None";
   if (atom == XA_STRING) return "STRING";
@@ -249,7 +250,7 @@ get_atom_name (Atom atom)
   if (atom == utf8_atom) return "UTF8_STRING";
 
   ret = XGetAtomName (display, atom);
-  strncpy (atom_name, ret, sizeof (atom_name));
+  strncpy (atom_name, ret, MAXLINE+1);
   if (atom_name[MAXLINE] != '\0')
     {
       atom_name[MAXLINE-3] = '.';
@@ -328,7 +329,7 @@ static char *
 _xs_strncpy (char * dest, const char * src, size_t n)
 {
   if (n > 0) {
-    strncpy (dest, src, n);
+    strncpy (dest, src, n-1);
     dest[n-1] = '\0';
   }
   return dest;


### PR DESCRIPTION
Also reserve unused extra char in get_atom_name to avoid gcc 8.3.0 error like:
```
x86_64-pc-linux-gnu-gcc -DHAVE_CONFIG_H -I.     -g -O2 -fno-strict-aliasing -Wall -Werror -g -std=gnu99 -Wdeclaration-after-statement -Wno-unused -c -o xsel.o xsel.c
In function 'get_atom_name.part.1',
    inlined from 'get_atom_name' at xsel.c:233:1:
xsel.c:252:3: error: 'strncpy' specified bound 4097 equals destination size [-Werror=stringop-truncation]
   strncpy (atom_name, ret, sizeof (atom_name));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In function '_xs_strncpy',
    inlined from 'main' at xsel.c:2114:7:
xsel.c:331:5: error: 'strncpy' specified bound 1024 equals destination size [-Werror=stringop-truncation]
     strncpy (dest, src, n);
     ^~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```