### PR TITLE
Remove interfering error message

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -2281,7 +2281,6 @@ main(int argc, char *argv[])
              old_sel[xs_strlen (old_sel) - 1] != '\n')
            {
              fflush (stdout);
-             fprintf (stderr, "\n\\ No newline at end of selection\n");
            }
       }
   }


### PR DESCRIPTION
This error message makes it impossible to use xsel in many workflows. I don't think anything is lost by removing it.

Also, I've been told by people who have tested this that the isatty() check is not helpful because it returns true; also for pty.