### PR TITLE
Fix MULTIPLE conversion requests

### DIFF
--- a/xsel.c
+++ b/xsel.c
@@ -1582,13 +1582,14 @@ handle_multiple (Display * display, Window requestor, Atom property,
 {
   MultTrack * mt;
   int format;
+  Atom type;
   unsigned long bytesafter;
   HandleResult retval = HANDLE_OK;
 
   mt = xs_malloc (sizeof (MultTrack));
 
   XGetWindowProperty (display, requestor, property, 0L, 1000000,
-                      False, (Atom)AnyPropertyType, &mt->property,
+                      False, (Atom)AnyPropertyType, &type,
                       &format, &mt->length, &bytesafter,
                       (unsigned char **)&mt->atoms);
 
@@ -1600,6 +1601,7 @@ handle_multiple (Display * display, Window requestor, Atom property,
   mt->display = display;
   mt->requestor = requestor;
   mt->sel = sel;
+  mt->property = property;
   mt->selection = selection;
   mt->time = time;
   mt->index = 0;

--- a/xsel.c
+++ b/xsel.c
@@ -1667,6 +1667,7 @@ handle_selection_request (XEvent event, unsigned char * sel)
       ev.property = None;
     } else {
       /* Handle MULTIPLE request */
+      ev.property = xsr->property;
       hr = handle_multiple (ev.display, ev.requestor, ev.property, sel,
                             ev.selection, ev.time, NULL);
     }


### PR DESCRIPTION
We were attempting to query the property with an uninitialized atom.

How did this bug happen? Does nobody use MULTIPLE? Or is it a recent regression?